### PR TITLE
chore(dependabot): allow major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,3 @@ updates:
     directory: '/' # Location of package manifests
     schedule:
       interval: 'weekly'
-    ignore:
-      - dependency-name: '*'
-        update-types: ['version-update:semver-major']


### PR DESCRIPTION
## Summary

Removes the blanket `ignore` rule in `.github/dependabot.yml` that suppressed all `version-update:semver-major` updates.

## Why

The previous config ignored major version bumps for every dependency, keeping the project pinned to potentially outdated or insecure major versions. Allowing Dependabot to open PRs for majors makes upgrades visible and reviewable.

## Changes
- Removed the `ignore` block (dependency-name: `'*'`, update-types: `['version-update:semver-major']`).

## Notes
- Weekly schedule and ecosystem (`npm`) are unchanged.
- If specific major upgrades prove risky later (e.g. React), re-add a scoped `ignore` entry for that dependency instead of the blanket `'*'`.